### PR TITLE
Template Close on External Click & Tweak Restore Attribute

### DIFF
--- a/src/components/contextMenu.tsx
+++ b/src/components/contextMenu.tsx
@@ -23,7 +23,7 @@ const MenuContext : React.FC<MenuContextProp> = ({ contextPosition, menuRef, pag
     >
       <ul>
         <li className='p-1' onClick={() => handlePageMove(pageIndex, "star")}>Star</li>
-        <li className='p-1' onClick={() => handlePageMove(pageIndex, "regular")}>Restore</li>
+        {page.Port ===  "trash" && <li className='p-1' onClick={() => handlePageMove(pageIndex, "regular")}>Restore</li>}
         <li className='p-1' onClick={() => handlePageDuplication(page)}>Duplicate</li>
         <li className='p-1' onClick={() => handlePageMove(pageIndex, "trash")}>Delete</li>
         <li className='p-1' onClick={() => handlePageMove(pageIndex, "permanent")}>Permanently Removed</li>

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -1,4 +1,4 @@
-import { useContext, useState, useEffect } from 'react';
+import { useContext, useState, useEffect, useRef } from 'react';
 import Icon from '../data/react-icons';
 import Private from "./private";
 import {IPage} from '../data/types.js';
@@ -23,6 +23,7 @@ const Navbar : React.FC = () => {
   }
 
   const [template, setTemplate] = useState(false)
+  const templateRef = useRef<HTMLDivElement>(null);
   
   /**
    * Acquire page template pop-up on adding new page
@@ -30,9 +31,9 @@ const Navbar : React.FC = () => {
    * @param e 
    * @returns 
    */
-  const handleTemplate : (apply : boolean, e? : KeyboardEvent) => void = (apply, e) => {
+  const handleTemplate : (apply : boolean, eK? : KeyboardEvent, eM? : MouseEvent) => void = (apply, eK, eM) => {
     if (apply) handlePageAdd(newPage)
-    else if (e && e?.key !== "Escape") return 
+    else if ((eK && eK?.key !== "Escape") || (eM && templateRef.current && templateRef.current.contains(eM.target as Node))) return 
     setTemplate(false)
   }
 
@@ -40,11 +41,14 @@ const Navbar : React.FC = () => {
    * Renders during unmounting to remove unconnected event listeners for template selection
    */
   useEffect(() => {
-    const handleKeyDown = (e : KeyboardEvent) => handleTemplate(false, e);
+    const handleKeyDown = (e : KeyboardEvent) => handleTemplate(false, e, undefined);
+    const handleMouseDown = (e : MouseEvent) => handleTemplate(false, undefined, e)
   
+    document.addEventListener('mousedown', handleMouseDown);
     document.addEventListener('keydown', handleKeyDown);
   
     return () => {
+      document.removeEventListener('mousedown', handleMouseDown);
       document.removeEventListener('keydown', handleKeyDown);
     };
   }, []);
@@ -87,7 +91,7 @@ const Navbar : React.FC = () => {
             </button>
           </li>
           {/* Prompts Template Page */}
-          {template && <Template handleTemplate={handleTemplate}/>}
+          {template && <Template templateRef={templateRef} handleTemplate={handleTemplate}/>}
           {/* Render Private Page List */}
           {pageList.filter((item : IPage) => item.Port === "regular").map((item : IPage, i : number) => <Private key={i} page={item}/>)}
           {/* Holds Calender, Templates, Trash */}

--- a/src/components/template.tsx
+++ b/src/components/template.tsx
@@ -1,20 +1,19 @@
-import { useState, useEffect, useRef, useContext } from 'react';
-import ContextMenu from './contextMenu'
-import UserContext from '../data/userContext';
-import { IPage } from '../data/types';
+import { RefObject } from 'react';
 
 interface templateProp{
+  templateRef : RefObject<HTMLDivElement>,
   handleTemplate: (apply : boolean, e? : KeyboardEvent) => void
 }
 
-const Template : React.FC<templateProp> = ({handleTemplate}) => {
+const Template : React.FC<templateProp> = ({ templateRef, handleTemplate }) => {
   return (
-    <>
-      <div className='absolute bg-amber-500 p-2 w-1/2 h-1/2'>
-        <button onClick={() => {handleTemplate(false)}}>Cancel</button>
-        <button onClick={() => {handleTemplate(true)}}>Apply</button>
-      </div>
-    </>
+    <div 
+      className='absolute bg-amber-500 p-2 w-1/2 h-1/2'
+      ref={templateRef}
+    >
+      <button onClick={() => {handleTemplate(false)}}>Cancel</button>
+      <button onClick={() => {handleTemplate(true)}}>Apply</button>
+    </div>
   );
 }
 


### PR DESCRIPTION
- Closed template context when mouse click outside of the context
- Restore attribute would no longer show unless page is in the delete list